### PR TITLE
Switch from Hatch to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Cookiecutter Mgczacki PyPackage
 
-Cookiecutter template for a cutting-edge Python package: Hatch, ruff, mypy, GitHub Actions and more!
+Cookiecutter template for a cutting-edge Python package: uv, ruff, mypy, GitHub Actions and more!
 
 ## Features
 
 * [X] Lightweight starter
-* [X] [Hatch](https://hatch.pypa.io/latest/install/) package management
+* [X] [uv](https://docs.astral.sh/uv/) package management
 * [X] Linting and formatting with [`ruff`](https://github.com/charliermarsh/ruff)
 * [X] Type checking with [`mypy`](https://github.com/python/mypy)
 * [X] Unit tests with [`pytest`](https://github.com/pytest-dev/pytest) with optional asyncio setup.
@@ -20,7 +20,7 @@ Generate the project:
 cookiecutter https://github.com/mgczacki/cookiecutter-template
 ```
 
-The generator will automatically call `hatch env create` at the end.
+The generator will automatically set up a `.venv` and install dependencies using `uv`.
 
 Then, for the GitHub Actions pipelines to work correctly, you should:
 

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -4,6 +4,12 @@ set -e
 
 git config core.hooksPath .githooks
 
-pip install hatch
+pip install uv
 
-hatch env create
+uv venv
+uv sync
+git init
+uv run pre-commit install
+git add .
+git commit -m 'Initializing project.' --no-verify
+git flow init -d -t v

--- a/{{cookiecutter.dist_name}}/README.md
+++ b/{{cookiecutter.dist_name}}/README.md
@@ -20,14 +20,14 @@
 
 ### Setup environment
 
-We use [Hatch](https://hatch.pypa.io/latest/install/) to manage the development environment and production build. Ensure it's installed on your system.
+We use [uv](https://docs.astral.sh/uv/) to manage the development environment and production build. Ensure it's installed on your system.
 
 ### Run unit tests
 
 You can run all the tests with:
 
 ```bash
-hatch run test
+uv run pytest
 ```
 
 ### Format the code
@@ -35,7 +35,9 @@ hatch run test
 Execute the following command to apply linting and check typing:
 
 ```bash
-hatch run lint
+uv run ruff format .
+uv run ruff --fix .
+uv run mypy {{ cookiecutter.package_name }}/
 ```
 
 ### Publish a new version
@@ -43,15 +45,15 @@ hatch run lint
 You can bump the version, create a commit and associated tag with one command:
 
 ```bash
-hatch version patch
+uv version patch
 ```
 
 ```bash
-hatch version minor
+uv version minor
 ```
 
 ```bash
-hatch version major
+uv version major
 ```
 
 Your default Git text editor will open so you can add information about the release.
@@ -63,7 +65,7 @@ When you push the tag on GitHub, the workflow will automatically publish it on P
 You can serve the Mkdocs documentation with:
 
 ```bash
-hatch run docs-serve
+uv run mkdocs serve
 ```
 
 It'll automatically watch for changes in your code.

--- a/{{cookiecutter.dist_name}}/pyproject.toml
+++ b/{{cookiecutter.dist_name}}/pyproject.toml
@@ -18,19 +18,8 @@ requires-python = ">={{ cookiecutter.python_version }}"
 [tool.hatch.metadata.hooks.requirements_txt]
 files = ["requirements.txt"]
 
-[tool.hatch]
-
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.hatch.version]
-#source = "regex_commit"
-#commit_extra_args = ["-e"]
-path = "{{ cookiecutter.package_name }}/__about__.py"
-
-[tool.hatch.envs.default]
-python = "{{ cookiecutter.python_version }}"
-dependencies = [
+[dependency-groups]
+dev = [
     "mypy",
     "ruff",
     "pre-commit",
@@ -42,29 +31,7 @@ dependencies = [
     "pytest-asyncio",
     {%- endif %}
 ]
-post-install-commands = [
-  "git init",
-  "pre-commit install",
-  "git add .",
-  "git commit -m 'Initializing project.' --no-verify",
-  "git flow init -d -t v"
-]
 
-[tool.hatch.envs.default.scripts]
-test = "pytest"
-test-cov-xml = "pytest --cov-report=xml"
-lint = [
-  "ruff format .",
-  "ruff --fix .",
-  "mypy {{ cookiecutter.package_name }}/",
-]
-lint-check = [
-  "ruff format --check .",
-  "ruff .",
-  "mypy {{ cookiecutter.package_name }}/",
-]
-docs-serve = "mkdocs serve"
-docs-build = "mkdocs build"
 
 [project.urls]
 Documentation = "{{ cookiecutter.docs_url }}"


### PR DESCRIPTION
## Summary
- switch to uv for project management
- use uv instead of hatch in docs
- sync environment and dev setup using uv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610e5c423483299df6aa761fc27b78